### PR TITLE
Update to Muzei 3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "io.github.muzplash"
         minSdkVersion 25

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,16 @@
                 android:name="settingsActivity"
                 android:value="io.github.muzplash.ui.settings.SettingsActivity" />
         </provider>
+
+        <provider android:name="com.google.android.apps.muzei.api.provider.MuzeiArtDocumentsProvider"
+            android:authorities="io.github.muzplash.unsplashartprovider.documents"
+            android:exported="true"
+            android:grantUriPermissions="true"
+            android:permission="android.permission.MANAGE_DOCUMENTS">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/muzplash/MuzeiExtensions.kt
+++ b/app/src/main/java/io/github/muzplash/MuzeiExtensions.kt
@@ -11,15 +11,15 @@ import io.github.unsplash.model.UnsplashPhoto
  */
 fun UnsplashPhoto.toArtwork(): Artwork {
     val photo = this
-    return Artwork().apply {
-        token = photo.id
-        title = photo.getDescriptionSummary() ?: photo.altDescription ?: photo.getDefaultDescription()
-        byline = photo.location?.title ?: photo.getFormattedCreationDate()
-        attribution = photo.user.getAttribution()
-        persistentUri = photo.urls.full.toUri()
-        webUri = photo.links.getUtmHtml("Muzplash").toUri()
+    return Artwork(
+        token = photo.id,
+        title = photo.getDescriptionSummary() ?: photo.altDescription ?: photo.getDefaultDescription(),
+        byline = photo.location?.title ?: photo.getFormattedCreationDate(),
+        attribution = photo.user.getAttribution(),
+        persistentUri = photo.urls.full.toUri(),
+        webUri = photo.links.getUtmHtml("Muzplash").toUri(),
         metadata = photo.location?.getGMapsUriString()
-    }
+    )
 }
 
 /**

--- a/app/src/main/java/io/github/muzplash/provider/UnsplashArtProvider.kt
+++ b/app/src/main/java/io/github/muzplash/provider/UnsplashArtProvider.kt
@@ -1,9 +1,11 @@
 package io.github.muzplash.provider
 
+import android.app.PendingIntent
 import android.content.Intent
 import android.util.Log
 import android.widget.Toast
-import com.google.android.apps.muzei.api.UserCommand
+import androidx.core.app.RemoteActionCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.google.android.apps.muzei.api.provider.Artwork
 import com.google.android.apps.muzei.api.provider.MuzeiArtProvider
 import io.github.muzplash.R
@@ -50,12 +52,17 @@ class UnsplashArtProvider : MuzeiArtProvider() {
         }
     }
 
-    override fun getCommands(artwork: Artwork): MutableList<UserCommand> {
-        val commands = super.getCommands(artwork)
-        if (artwork.isGeolocated()) commands.add(UserCommand(USER_COMMAND_ID_GMAPS, context?.getString(R.string.provider_command_gmaps)))
-        return commands
+    /* kept for backward compatibility with Muzei 3.3 */
+    @Suppress("OverridingDeprecatedMember", "DEPRECATION")
+    override fun getCommands(artwork: Artwork) = if (artwork.isGeolocated()) {
+        listOf(com.google.android.apps.muzei.api.UserCommand(USER_COMMAND_ID_GMAPS,
+                context?.getString(R.string.provider_command_gmaps)))
+    } else {
+        emptyList()
     }
 
+    /* kept for backward compatibility with Muzei 3.3 */
+    @Suppress("OverridingDeprecatedMember")
     override fun onCommand(artwork: Artwork, id: Int) {
         when(id) {
             USER_COMMAND_ID_GMAPS -> {
@@ -71,6 +78,20 @@ class UnsplashArtProvider : MuzeiArtProvider() {
                 }
             }
         }
+    }
+
+    /* Used by Muzei 3.4+ */
+    override fun getCommandActions(artwork: Artwork)= if (artwork.isGeolocated()) {
+        listOf(RemoteActionCompat(
+                IconCompat.createWithResource(context, R.drawable.muzei_launch_command),
+                context?.getString(R.string.provider_command_gmaps) ?: "",
+                context?.getString(R.string.provider_command_gmaps) ?: "",
+                PendingIntent.getActivity(context, 0,
+                        Intent(Intent.ACTION_VIEW, artwork.getGMapsUri()), 0)).apply {
+            setShouldShowIcon(false)
+        })
+    } else {
+        emptyList()
     }
 
     // TODO override useful methods like getCommands and getDescription

--- a/app/src/main/java/io/github/muzplash/provider/UnsplashWorker.kt
+++ b/app/src/main/java/io/github/muzplash/provider/UnsplashWorker.kt
@@ -15,7 +15,7 @@ class UnsplashWorker(private val context: Context, parameters: WorkerParameters)
 
     override fun doWork(): Result {
         val photos = UnsplashPhotoSupplier(MuzplashSettingsImpl(context)).get()
-        val providerClient = ProviderContract.getProviderClient(applicationContext, UnsplashArtProvider::class.java)
+        val providerClient = ProviderContract.getProviderClient<UnsplashArtProvider>(applicationContext)
         providerClient.addArtwork(photos.map { it.toArtwork() })
         return Result.success()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.3.31'
-        muzei_api_version = '3.1.0'
+        kotlin_version = '1.3.72'
+        muzei_api_version = '3.4.0'
         work_version = '2.0.1'
         retrofit_version = '2.5.0'
     }
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 12 11:55:00 CEST 2019
+#Thu Jul 23 21:10:32 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Use the new `getCommandActions()` API to fix the 'Open location' actions on Android 10+ devices. By keeping the old APIs as well, we maintain backward compatibility with Muzei 3.3 users (although the action still won't work for those users who are running Android 10+ - they'll still need to upgrade to Muzei 3.4).

The `UnsplashWorker` and `MuzeiExtensions` were changed to be compatible with the Kotlin rewrite of the Muzei API and use the reified version of `getProviderClient()` to avoid the `::class.java` stuff that was previously required.

The `MuzeiArtDocumentsProvider` was added to the manifest to allow users to select artwork from the Source via the default file picker / Files app.

Muzei API 3.4 requires Kotlin 1.3.72 and a `compileSdkVersion` of 30 (which then required we upgrade the Android Gradle Plugin to 4.0.1), so those were also updated.